### PR TITLE
Starting colors and selected indices bug fix

### DIFF
--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -202,7 +202,9 @@ class Scatter(Artist):
         else:
             # If the scatter plot already exists, just update its data
             self._scatter.set_offsets(value)
-        if self._color_indices is not None:
+        if self._color_indices is None:
+            self.color_indices = 0  # Set default color index
+        else:
             # Update colors if color indices are set
             self.color_indices = self._color_indices
         self.draw()

--- a/src/biaplotter/plotter.py
+++ b/src/biaplotter/plotter.py
@@ -213,6 +213,7 @@ class CanvasWidget(SingleAxesWidget):
                     button.setChecked(False)
             # Remove all selectors
             for selector in self.selectors.values():
+                selector.selected_indices = None
                 selector.remove()
             # Create the chosen selector
             for selector_type, selector in self.selectors.items():
@@ -222,6 +223,7 @@ class CanvasWidget(SingleAxesWidget):
             # If the button is unchecked, remove the selector
             for selector_type, selector in self.selectors.items():
                 if selector_type.name == sender_name:
+                    selector.selected_indices = None
                     selector.remove()
 
     @property

--- a/src/biaplotter/selectors.py
+++ b/src/biaplotter/selectors.py
@@ -381,8 +381,6 @@ class Interactive(Selector):
     @selected_indices.setter
     def selected_indices(self, value: np.ndarray):
         """Sets the indices of the selected points."""
-        if value is None:
-            return
         self._selected_indices = value
 
     def on_button_press(self, event):


### PR DESCRIPTION
Fix bug where scatter plot was not visible because `.color_indices` were never set after setting `.data`

Fix bug where re-enabling a selector would color previous selection if right-click was done (clearing `.selected_indices` when disabling selector solves it).