### PR TITLE
de-construct `color_indices` setter into separate subfunctions

### DIFF
--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -321,6 +321,7 @@ class Scatter(Artist):
     def overlay_colormap(self, value: Colormap):
         """Sets the overlay colormap for the scatter plot."""
         self._overlay_colormap = BiaColormap(value)
+        self.color_indices = self._color_indices
 
     @property
     def overlay_visible(self) -> bool:

--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -321,7 +321,6 @@ class Scatter(Artist):
     def overlay_colormap(self, value: Colormap):
         """Sets the overlay colormap for the scatter plot."""
         self._overlay_colormap = BiaColormap(value)
-        self.color_indices = self._color_indices
 
     @property
     def overlay_visible(self) -> bool:

--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -253,7 +253,7 @@ class Scatter(Artist):
             norm = self._get_normalization(indices)
             rgba_colors = self._get_rgba_colors(indices, norm)
             self._scatter.set_facecolor(rgba_colors)
-            self._scatter.set_edgecolor('None')
+            self._scatter.set_edgecolor('white')
     
         # emit signal
         self.color_indices_changed_signal.emit(self._color_indices)

--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -290,11 +290,12 @@ class Scatter(Artist):
     
     def _log_normalization(self, indices, norm_class):
         """Apply log normalization to indices."""
-        min_value = np.nanmin(indices)
-        if min_value <= 0:
+        if np.nanmin(indices) <= 0:
             warnings.warn(
                 f'Log normalization applied to values <= 0. Values below 0 were set to np.nan')
-        indices[indices <= 0] = min_value
+            indices[indices <= 0] = np.nan
+        min_value = np.nanmin(indices)
+
         return norm_class(vmin=min_value, vmax=np.nanmax(indices))
     
     def _get_rgba_colors(self, indices, norm):

--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -248,50 +248,62 @@ class Scatter(Artist):
         if np.isscalar(indices):
             indices = np.full(len(self._data), indices)
         self._color_indices = indices
+    
         if indices is not None and self._scatter is not None:
-            norm_class = self._normalization_methods[self._color_normalization_method]
-            # If overlay_colormap is categorical, normalize to colormap range
-            if self.overlay_colormap.categorical:
-                if self._color_indices.dtype != int:
-                    warnings.warn(
-                        'Color indices must be integers for categorical colormap. Change `overlay_colormap` to a continuous colormap or set `color_indices` to integers.')
-                if self._color_normalization_method != 'linear':
-                    warnings.warn(
-                        'Categorical colormap detected. Setting color normalization method to linear.')
-                    self._color_normalization_method = 'linear'
-                norm = Normalize(vmin=0, vmax=self.overlay_colormap.N)
-            else:
-                with warnings.catch_warnings():
-                    # If array is all NaN, ignore warning since it will be displayed transparent
-                    warnings.filterwarnings(
-                        'ignore', r'All-NaN slice encountered')
-                    if self._color_normalization_method == 'log':
-                        min_value = np.nanmin(self._color_indices)
-                        if min_value <= 0:
-                            min_value = 0.01
-                        norm = norm_class(vmin=min_value, vmax=np.nanmax(self._color_indices))
-                        warnings.warn(
-                            f'Log normalization applied to color indices with min value {min_value}. Values below 0.01 were set to 0.01.')
-                        indices[indices <= 0] = min_value
-                    elif self._color_normalization_method == 'centered':
-                        norm = norm_class(vcenter=np.nanmean(self._color_indices))
-                    elif self._color_normalization_method == 'symlog':
-                        norm = norm_class(vmin=np.nanmin(self._color_indices), vmax=np.nanmax(self._color_indices), linthresh=0.03)
-                    else:
-                        norm = norm_class(vmin=np.nanmin(self._color_indices), vmax=np.nanmax(self._color_indices))
-
-            # Create a ScalarMappable instance using chosen colormap and normalization
-            sm = ScalarMappable(norm=norm, cmap=self.overlay_colormap.cmap)
-            # Convert normalized data to RGBA
-            rgba_colors = sm.to_rgba(indices)
-            # Set color light gray if overlay is not visible
-            if not self._overlay_visible:
-                rgba_colors = cat10_mod_cmap(0) # Set colors to light gray
+            norm = self._get_normalization(indices)
+            rgba_colors = self._get_rgba_colors(indices, norm)
             self._scatter.set_facecolor(rgba_colors)
-            self._scatter.set_edgecolor(None)
+            self._scatter.set_edgecolor('None')
+    
         # emit signal
         self.color_indices_changed_signal.emit(self._color_indices)
         self.draw()
+    
+    def _get_normalization(self, indices):
+        """Determine the normalization method and return the normalization object."""
+        norm_class = self._normalization_methods[self._color_normalization_method]
+    
+        if self.overlay_colormap.categorical:
+            self._validate_categorical_colormap()
+            return Normalize(vmin=0, vmax=self.overlay_colormap.N)
+    
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'All-NaN slice encountered')
+            if self._color_normalization_method == 'log':
+                return self._log_normalization(indices, norm_class)
+            elif self._color_normalization_method == 'centered':
+                return norm_class(vcenter=np.nanmean(self._color_indices))
+            elif self._color_normalization_method == 'symlog':
+                return norm_class(vmin=np.nanmin(self._color_indices), vmax=np.nanmax(self._color_indices), linthresh=0.03)
+            else:
+                return norm_class(vmin=np.nanmin(self._color_indices), vmax=np.nanmax(self._color_indices))
+    
+    def _validate_categorical_colormap(self):
+        """Validate settings for a categorical colormap."""
+        if self._color_indices.dtype != int:
+            warnings.warn(
+                'Color indices must be integers for categorical colormap. Change `overlay_colormap` to a continuous colormap or set `color_indices` to integers.')
+        if self._color_normalization_method != 'linear':
+            warnings.warn(
+                'Categorical colormap detected. Setting color normalization method to linear.')
+            self._color_normalization_method = 'linear'
+    
+    def _log_normalization(self, indices, norm_class):
+        """Apply log normalization to indices."""
+        min_value = np.nanmin(indices)
+        if min_value <= 0:
+            warnings.warn(
+                f'Log normalization applied to values <= 0. Values below 0 were set to np.nan')
+        indices[indices <= 0] = min_value
+        return norm_class(vmin=min_value, vmax=np.nanmax(indices))
+    
+    def _get_rgba_colors(self, indices, norm):
+        """Convert normalized data to RGBA colors."""
+        sm = ScalarMappable(norm=norm, cmap=self.overlay_colormap.cmap)
+        rgba_colors = sm.to_rgba(indices)
+        if not self._overlay_visible:
+            rgba_colors = cat10_mod_cmap(0)  # Set colors to light gray
+        return rgba_colors
 
     @property
     def overlay_colormap(self) -> BiaColormap:

--- a/src/biaplotter/selectors.py
+++ b/src/biaplotter/selectors.py
@@ -413,7 +413,7 @@ class Interactive(Selector):
         if self._selected_indices is not None:
             if len(self._selected_indices) > 0:
                 # if overlay_colormap of the active artist is not cat10_mod_cmap, set it to cat10_mod_cmap
-                if not self._active_artist.overlay_colormap.cmap.name.startswith('cat10_mod_cmap'):
+                if not self._active_artist.overlay_colormap.cmap.name.startswith('cat10'):
                     # Clear previous color indices to remove previous feature coloring
                     self._active_artist.color_indices = 0
                     if type(self._active_artist).__name__ == 'Scatter':

--- a/src/biaplotter/selectors.py
+++ b/src/biaplotter/selectors.py
@@ -346,7 +346,7 @@ class Interactive(Selector):
 
     """
     #: Signal emitted when the `apply_selection` is called. Let's the canvas widget know that color_indices were updated because of a selection.
-    selection_applied_signal: Signal = Signal(bool)
+    selection_applied_signal: Signal = Signal(np.ndarray)
     def __init__(self, ax: plt.Axes, canvas_widget: "CanvasWidget", data: np.ndarray = None):
         """Initializes the interactive selectors.
         """
@@ -431,7 +431,7 @@ class Interactive(Selector):
         self._active_artist.color_indices = color_indices
 
         # Emit signal and reset selected indices
-        self.selection_applied_signal.emit(True)
+        self.selection_applied_signal.emit(color_indices)
         self._selected_indices = None
         # Remove selector and create a new one
         self.remove()


### PR DESCRIPTION
Hi @zoccoler , just a bit of refactoring to make the code easier to read. Long description:

This pull request includes several updates to the `color_indices` method in the `src/biaplotter/artists.py` file. The changes primarily focus on improving the normalization process, handling categorical colormaps, and updating the scatter plot colors accordingly.

Normalization and colormap handling improvements:

* Added the `_get_normalization` method to determine the normalization method and return the appropriate normalization object. This method handles different normalization methods such as 'log', 'centered', and 'symlog'.
* Introduced the `_validate_categorical_colormap` method to ensure settings are correct for categorical colormaps, including warnings and adjustments to the normalization method.
* Added the `_log_normalization` method to apply log normalization to indices, setting values below zero to NaN and issuing warnings accordingly.

Scatter plot color updates:

* Added the `_get_rgba_colors` method to convert normalized data to RGBA colors and update the scatter plot colors.
* Updated the `color_indices` method to set scatter plot face and edge colors based on the normalized RGBA colors and emit a signal when color indices change.