### PR TITLE
Add data ids

### DIFF
--- a/docs/artists_api.md
+++ b/docs/artists_api.md
@@ -9,13 +9,14 @@
 
    .. autosummary::
 
-      ~Artist.data
-      ~Artist.visible
       ~Artist.color_indices
+      ~Artist.data
+      ~Artist.ids
       ~Artist.overlay_colormap
+      ~Artist.visible
       ~Artist.x_label_text
-      ~Artist.y_label_text
       ~Artist.x_label_color
+      ~Artist.y_label_text
       ~Artist.y_label_color
 
    .. rubric:: Attributes Summary
@@ -32,13 +33,14 @@
 
    .. rubric:: Properties Documentation
 
-   .. autoattribute:: data
-   .. autoattribute:: visible
    .. autoattribute:: color_indices
+   .. autoattribute:: data
+   .. autoattribute:: ids
    .. autoattribute:: overlay_colormap
+   .. autoattribute:: visible
    .. autoattribute:: x_label_text
-   .. autoattribute:: y_label_text
    .. autoattribute:: x_label_color
+   .. autoattribute:: y_label_text
    .. autoattribute:: y_label_color
 
    .. rubric:: Attributes Documentation

--- a/docs/plotter_api.md
+++ b/docs/plotter_api.md
@@ -29,7 +29,7 @@
 
       ~CanvasWidget.artist_changed_signal
       ~CanvasWidget.selector_changed_signal
-      ~CanvasWidget.show_overlay_signal
+      ~CanvasWidget.show_color_overlay_signal
 
    .. rubric:: Properties Documentation
 
@@ -49,5 +49,5 @@
 
    .. autoattribute:: artist_changed_signal
    .. autoattribute:: selector_changed_signal
-   .. autoattribute:: show_overlay_signal
+   .. autoattribute:: show_color_overlay_signal
 ```

--- a/src/biaplotter/artists_base.py
+++ b/src/biaplotter/artists_base.py
@@ -198,6 +198,8 @@ class Artist(ABC):
         value : (N,) np.ndarray[int]
             Array of IDs. Must have the same length as the data.
         """
+        if self._data is None:
+            raise ValueError("Cannot set ids because data is not initialized.")
         if value is not None and len(value) != len(self._data):
             raise ValueError("Length of ids must match the length of data.")
         self._ids = value


### PR DESCRIPTION
This pull request introduces enhancements to the `Artist` class and its associated documentation, focusing on adding a new `ids` attribute for data point identification, improving validation for `color_indices`, and updating the API documentation. Additionally, a signal name in the `CanvasWidget` class has been updated for better clarity. Below are the most significant changes:

This would solve #55 

### Enhancements to `Artist` class:

* Added a new private `_ids` attribute to the `Artist` class to store unique IDs for data points, initialized in `__init__` and reset in the `reset` method. [[1]](diffhunk://#diff-2b42a7f6793bfc2372f5194c780bf97ddd88ab24d7555097d9c700f716fa94fdR43) [[2]](diffhunk://#diff-2b42a7f6793bfc2372f5194c780bf97ddd88ab24d7555097d9c700f716fa94fdR89)
* Updated the `data` setter to automatically generate IDs if they are not set or if their length does not match the data length.
* Introduced a new `ids` property with getter and setter methods, allowing users to access and modify the IDs while ensuring they match the data length.
* Enhanced the `color_indices` setter to validate that the length of indices matches the data length, raising a `ValueError` if not.

### Documentation updates:

* Updated `docs/artists_api.md` to include the new `ids` attribute and reordered existing attributes for consistency. [[1]](diffhunk://#diff-4d8b48970828d7619246631516a077a37fba3281caffc5a8ee118d46d6d68b4eL12-R19) [[2]](diffhunk://#diff-4d8b48970828d7619246631516a077a37fba3281caffc5a8ee118d46d6d68b4eL35-R43)
* Renamed the `CanvasWidget.show_overlay_signal` to `CanvasWidget.show_color_overlay_signal` in `docs/plotter_api.md` for improved clarity. [[1]](diffhunk://#diff-998fd09e20af3582e2e66edc3431df5b35ea993c451e3256e0384c15f888d269L32-R32) [[2]](diffhunk://#diff-998fd09e20af3582e2e66edc3431df5b35ea993c451e3256e0384c15f888d269L52-R52)