### PR TITLE
Add a sphinx.configuration key

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
       # Generate on-the-fly Sphinx configuration from Jupyter Book's _config.yml
       - "jupyter-book config sphinx docs/"
 
+sphinx:
+  configuration: docs/conf.py
+
 python:
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
This pull request updates the Read the Docs configuration to specify the Sphinx configuration file explicitly, improving the build process for documentation.

Documentation build configuration:

* [`.readthedocs.yaml`](diffhunk://#diff-03efc769b870804394632e45d7885272b44c16939517fb31c9d7c614d2ffae57R13-R15): Added a `sphinx` section to explicitly define the Sphinx configuration file as `docs/conf.py`. This ensures that the correct configuration is used during the documentation build process.