### PR TITLE
added default sizes as properties

### DIFF
--- a/src/biaplotter/_tests/test_artists.py
+++ b/src/biaplotter/_tests/test_artists.py
@@ -79,10 +79,9 @@ def test_scatter():
 
     # Test size reset when new data is set
     scatter.data = np.random.rand(size // 2, 2)
-    correct_size = min(10, (max(0.1, 8000 / len(scatter.data)))) * 4
-    assert np.all(scatter.size == correct_size)  # that's the default
+    assert np.all(scatter.size == scatter.default_size)  # that's the default
     sizes = scatter._mpl_artists["scatter"].get_sizes()
-    assert np.all(sizes == correct_size)
+    assert np.all(sizes == scatter.default_size)
 
     # test alpha
     scatter.alpha = 0.5

--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -228,7 +228,7 @@ class Scatter(Artist):
     @property
     def default_size(self) -> float:
         """rule of thumb for good point size"""
-        return min(10, (max(0.1, 8000 / len(self._data)))) * 4
+        return min(10, (max(0.1, 8000 / len(self._data)))) * 2
 
     @property
     def default_edge_width(self) -> float:

--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -211,14 +211,10 @@ class Scatter(Artist):
             self._mpl_artists["scatter"] = self.ax.scatter(
                 self._data[:, 0], self._data[:, 1]
             )
-
-            # rule of thumb for good point size
-            _size = min(10, (max(0.1, 8000 / len(self._data)))) * 4
-            _edge_width = np.sqrt(_size/np.pi) / 8
-            self.size = _size
+            self.size = self.default_size
 
             if "scatter" in self._mpl_artists.keys():
-                self._mpl_artists["scatter"].set_linewidth(_edge_width)
+                self._mpl_artists["scatter"].set_linewidth(self.default_edge_width)
             self.alpha = 1  # Default alpha
             self.color_indices = 0
         else:
@@ -228,6 +224,16 @@ class Scatter(Artist):
             self.color_indices = self._color_indices
             self.size = self._size
             self.alpha = self._alpha
+
+    @property
+    def default_size(self) -> float:
+        """rule of thumb for good point size"""
+        return min(10, (max(0.1, 8000 / len(self._data)))) * 4
+
+    @property
+    def default_edge_width(self) -> float:
+        """Calculate the default edge width based on the point size."""
+        return np.sqrt(self.default_size / np.pi) / 8
 
     def _validate_categorical_colormap(self):
         """Validate settings for a categorical colormap."""


### PR DESCRIPTION
Hi @zoccoler ,

minor change regarding how we are auto-calculating the point sizes for crowded plots. I added the default point size and edgewidths as properties which encapsulate the formula we tinkered yesterday.

That makes it a fair bit easier to revert back to a good point size for any number of plots when using the biaplotter from elsewhere.