### PR TITLE
silence id/data error

### DIFF
--- a/src/biaplotter/artists_base.py
+++ b/src/biaplotter/artists_base.py
@@ -249,10 +249,6 @@ class Artist(ABC):
         # Check if indices are a scalar
         if np.isscalar(indices):
             indices = np.full(len(self._data), indices)
-        # elif len(indices) != len(self._data):
-        #     raise ValueError(
-        #         f"Length of indices ({len(indices)}) must match length of data ({len(self._data)})"
-        #     )
         self._color_indices = indices
 
         if indices is not None and self._mpl_artists:


### PR DESCRIPTION
Fixes #65 

This pull request includes a modification to the `color_indices` method in `src/biaplotter/artists_base.py`, specifically commenting out the validation that ensures the length of `indices` matches the length of `self._data`.

Key change:

* [`src/biaplotter/artists_base.py`](diffhunk://#diff-2b42a7f6793bfc2372f5194c780bf97ddd88ab24d7555097d9c700f716fa94fdL252-R255): Commented out the check that raises a `ValueError` if the length of `indices` does not match the length of `self._data`, potentially allowing mismatched lengths without error handling.