### PR TITLE
Update CI matrix to use latest macOS and Python versions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -22,13 +22,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-13, macos-14]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - python-version: "3.9"
-            platform: macos-14
-          - python-version: "3.9"
-            platform: macos-13
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Replaces specific macOS versions with macos-latest and removes Python 3.9 from the test matrix. Simplifies the matrix by removing exclusions for older macOS and Python combinations.