### PR TITLE
Relax numpy upper version constraint in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization"
 ]
 dependencies = [
-    "numpy>=1.22.0,<2.0.0",
+    "numpy>=1.22.0",
     "magicgui",
     "qtpy",
     "napari-matplotlib",


### PR DESCRIPTION
Removed the upper version limit for numpy in the dependencies list in pyproject.toml to allow compatibility with future numpy releases.