### PR TITLE
enhancement: adjust ax limits on redraw

### DIFF
--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -296,6 +296,11 @@ class Scatter(Artist):
             self.alpha = self._alpha
             self.color_indices = self._color_indices
 
+        # update x/y-limits to data range
+        self.ax.set_xlim(np.min(self._data[:, 0]), np.max(self._data[:, 0]))
+        self.ax.set_ylim(np.min(self._data[:, 1]), np.max(self._data[:, 1]))
+
+
     @property
     def default_size(self) -> float:
         """Rule of thumb for good point size based on the number of points.

--- a/src/biaplotter/artists.py
+++ b/src/biaplotter/artists.py
@@ -297,8 +297,8 @@ class Scatter(Artist):
             self.color_indices = self._color_indices
 
         # update x/y-limits to data range
-        self.ax.set_xlim(np.min(self._data[:, 0]), np.max(self._data[:, 0]))
-        self.ax.set_ylim(np.min(self._data[:, 1]), np.max(self._data[:, 1]))
+        self.ax.set_xlim(np.nanmin(self._data[:, 0]), np.nanmax(self._data[:, 0]))
+        self.ax.set_ylim(np.nanmin(self._data[:, 1]), np.nanmax(self._data[:, 1]))
 
 
     @property


### PR DESCRIPTION
@zoccoler tiny PR that bugged me. In the current version, we removed the code that reset the ax limits at some point. So in the clusters plotter, if you choose a different set of features, you end up having to pan/zoom in the plotter quite a bit until you find your data again 🙈 